### PR TITLE
Fix loss of exception in NativePayments.show()

### DIFF
--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -442,7 +442,8 @@ export default class PaymentRequest {
       const normalizedDetails = convertDetailAmountsToString(this._details);
       const options = this._options;
 
-      return NativePayments.show(platformMethodData, normalizedDetails, options);
+      // Note: resolve will be triggered via _acceptPromiseResolver() from somwhere else
+      NativePayments.show(platformMethodData, normalizedDetails, options).catch(reject);
     });
 
     return this._acceptPromise;


### PR DESCRIPTION
[43.patch.txt](https://github.com/ExodusMovement/react-native-payments/files/4004376/43.patch.txt)