### PR TITLE
fix canMakePayments result value on Android

### DIFF
--- a/packages/react-native-payments/lib/js/NativePayments.js
+++ b/packages/react-native-payments/lib/js/NativePayments.js
@@ -28,7 +28,7 @@ const NativePayments: {
         ReactNativePayments.canMakePayments(
           methodData,
           (err) => reject(err),
-          (canMakePayments) => resolve(true)
+          (canMakePayments) => resolve(canMakePayments)
         );
 
         return;


### PR DESCRIPTION
noticed while auditing

untested, but seems more accurate given where it comes from:
https://github.com/ExodusMovement/react-native-payments/blob/5b45f79452009f7f48a6d3e762db885f47d67357/packages/react-native-payments/android/src/main/java/com/reactnativepayments/ReactNativePaymentsModule.java#L170