### PR TITLE
fix: android openPaymentSetup

### DIFF
--- a/packages/react-native-payments/lib/js/NativePayments.js
+++ b/packages/react-native-payments/lib/js/NativePayments.js
@@ -177,7 +177,7 @@ const NativePayments: {
     });
   },
 
-  openPaymentSetup: ReactNativePayments.openPaymentSetup || noop
+  openPaymentSetup: ReactNativePayments && ReactNativePayments.openPaymentSetup || noop
 };
 
 export default NativePayments;


### PR DESCRIPTION
didn't realize android doesn't have ReactNativePayments