### PR TITLE
Adds a method that stops the request without rejecting

### DIFF
--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -403,10 +403,10 @@ export default class PaymentRequest {
     return this._acceptPromiseRejecter(new GatewayError(details.error));
   }
 
-  _closePaymentRequest() {
+  _closePaymentRequest(reject = true) {
     this._state = 'closed';
 
-    this._acceptPromiseRejecter(new Error('AbortError'));
+    if (reject) this._acceptPromiseRejecter(new Error('AbortError'));
 
     // Remove event listeners before aborting.
     this._removeEventListeners();
@@ -425,6 +425,10 @@ export default class PaymentRequest {
         this._shippingOptionChangeSubscription
       );
     }
+  }
+
+  stopRequest() {
+    if (this._state !== 'closed') this._closePaymentRequest(false)
   }
 
   // https://www.w3.org/TR/payment-request/#onshippingaddresschange-attribute


### PR DESCRIPTION
Current use case for this is stopping requests that error out before we show the apple sheet. Such request would have active listeners that might crash the app on successive requests.