### PR TITLE
refactor: drop "validator" dep

### DIFF
--- a/packages/react-native-payments/lib/js/helpers/__tests__/index-test.js
+++ b/packages/react-native-payments/lib/js/helpers/__tests__/index-test.js
@@ -1,7 +1,6 @@
 const {
   isValidDecimalMonetaryValue,
   isValidStringAmount,
-  toNumber
 } = require('..');
 
 describe('helpers', () => {
@@ -46,24 +45,6 @@ describe('helpers', () => {
 
     it('`9.` should not be a valid string amount', () => {
       expect(isValidStringAmount('9.')).toBe(false);
-    });
-  });
-
-  describe('toNumber', () => {
-    it('"9.999" should convert to 9.999', () => {
-      expect(toNumber('9.999')).toBe(9.999);
-    });
-
-    it('"9.99" should convert to 9.99', () => {
-      expect(toNumber('9.99')).toBe(9.99);
-    });
-
-    it('"9.9" should convert to 9.9', () => {
-      expect(toNumber('9.9')).toBe(9.9);
-    });
-
-    it('"9" should convert to 9', () => {
-      expect(toNumber('9')).toBe(9);
     });
   });
 });

--- a/packages/react-native-payments/lib/js/helpers/index.js
+++ b/packages/react-native-payments/lib/js/helpers/index.js
@@ -4,7 +4,6 @@ import type {
   PaymentShippingOption
 } from '../types';
 
-import { isDecimal, isFloat, isInt, toFloat, toInt } from 'validator';
 import { DOMException, ConstructorError } from '../errors';
 
 type AmountValue = string | number;
@@ -32,21 +31,11 @@ export function isNegative(amountValue: AmountValue): boolean {
 }
 
 export function isValidStringAmount(stringAmount): boolean {
-  if (stringAmount.endsWith('.')) {
-    return false;
-  }
+  if (typeof stringAmount !== 'string') throw new TypeError('Expected a string');
 
-  return isDecimal(stringAmount);
-}
-
-export function toNumber(string: string): number {
-  if (isFloat(string)) {
-    return toFloat(string);
-  }
-
-  if (isInt(string)) {
-    return toInt(string);
-  }
+  // '9', '.9' and '9.9' are correct
+  // '9.', '.' and '' are not
+  return /^[-+]?(?:\.[0-9]+|[0-9]+(?:\.[0-9]+)?)$/.test(stringAmount);
 }
 
 export function toString(amountValue: AmountValue) {

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -22,8 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@exodus/crypto": "^1.0.0-rc.2",
-    "es6-error": "^4.0.2",
-    "validator": "^7.0.0"
+    "es6-error": "^4.0.2"
   },
   "devDependencies": {
     "babel-jest": "20.0.3",

--- a/packages/react-native-payments/yarn.lock
+++ b/packages/react-native-payments/yarn.lock
@@ -2312,10 +2312,6 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-validator@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-7.0.0.tgz#c74deb8063512fac35547938e6f0b1504a282fd2"
-
 verror@1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"


### PR DESCRIPTION
1. Removed unused (and incorrect) `toNumber`
2. `isValidStringAmount` is now implemented without `validator` dep.

`validator` is large: https://bundlephobia.com/package/validator@7.0.0