### PR TITLE
feat: isSupported const

### DIFF
--- a/src/js/NativePayments.ts
+++ b/src/js/NativePayments.ts
@@ -49,11 +49,13 @@ const IS_ANDROID = Platform.OS === 'android';
 
 const noop = () => {};
 
+const isSupported = IS_ANDROID ? false :ReactNativePayments.canMakePayments
+
 // For Android: ReactNativePayments.canMakePayments(methodData, err => reject(err), canMakePayments => resolve(canMakePayments));
 // On iOS, canMakePayments is exposed as a constant.
 function canMakePayments(): Promise<boolean> {
   return new Promise((resolve, reject) => {
-    resolve(IS_ANDROID ? false :ReactNativePayments.canMakePayments);
+    resolve(isSupported);
   });
 }
 
@@ -178,6 +180,7 @@ const openPaymentSetup =
 // }
 
 const NativePayments = {
+  isSupported,
   canMakePayments,
   canMakePaymentsUsingNetworks,
   createPaymentRequest,

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -3,4 +3,5 @@ import NativePayments from './NativePayments';
 
 export const PaymentRequest = _PaymentRequest;
 export const openPaymentSetup = NativePayments.openPaymentSetup;
+export const isSupported = NativePayments.isSupported;
 export * from './types';


### PR DESCRIPTION
not sure why we need canMakePayments async function, i guess just to adhere to the spec